### PR TITLE
Fix: vm-vomuses missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 __pycache__/
-vm-volumes/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 vm-volumes
-vm-co

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+vm-volumes
+vm-co

--- a/vm-volumes/team0-root/.gitignore
+++ b/vm-volumes/team0-root/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/vm-volumes/team1-root/.gitignore
+++ b/vm-volumes/team1-root/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/vm-volumes/team2-root/.gitignore
+++ b/vm-volumes/team2-root/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/vm-volumes/team3-root/.gitignore
+++ b/vm-volumes/team3-root/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
After cloning and running: 
```sh
docker compose up
```

There is an error due to the lack of vm-volumes dir and subdirs.

I fixed doing the following actions:

- removed vm-volumes line from .gitignore
- added .gitkeep -> added vm-volumes
- added .gitignore inside subdirs to ensure no files will be pushed on intentionally empty dirs


Cheers,
Carlo